### PR TITLE
Improve directory handling of mount target

### DIFF
--- a/Cake.UncUtils.Test/Tests.cs
+++ b/Cake.UncUtils.Test/Tests.cs
@@ -31,12 +31,7 @@ namespace Cake.UncUtils.Test
 		{
 			var source = (string) _config.source;
 			var target = (string) _config.target;
-
-			if (Directory.Exists(target))
-			{
-				Directory.Delete(target);
-			}
-
+			
 			_context.CakeContext.MountUncDir(source, target);
 
 			DirectoryAssert.Exists(target);


### PR DESCRIPTION
These improvement are helpful to use `DirectoryPath.FullName` in your cake-script since it results in something like `C:/Temp/...`.

Use `DirectoryInfo` to be able to handle arguments either with `\` or
with `/` as separator. If the target exists and is not empty, an
exception will be thrown. Otherwise the target directory will be deleted
to allow the mounting.
Deletion of target in test not longer needed since it is handled by `MountUncDir`.