### PR TITLE
Update cake reference

### DIFF
--- a/Cake.UncUtils.Test/Cake.UncUtils.Test.csproj
+++ b/Cake.UncUtils.Test/Cake.UncUtils.Test.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.UncUtils.Test</RootNamespace>
     <AssemblyName>Cake.UncUtils.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,11 +33,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.22.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Cake.Core.0.22.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Testing, Version=0.17.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Cake.Testing.0.17.1\lib\net45\Cake.Testing.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.22.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Cake.Testing.0.22.0\lib\net46\Cake.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
@@ -66,6 +66,9 @@
       <Project>{FA10631A-DD1F-4218-90DA-42F067D3347D}</Project>
       <Name>Cake.UncUtils</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Cake.UncUtils.Test/packages.config
+++ b/Cake.UncUtils.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
-  <package id="Cake.Testing" version="0.17.1" targetFramework="net45" />
+  <package id="Cake.Core" version="0.22.0" targetFramework="net46" />
+  <package id="Cake.Testing" version="0.22.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
 </packages>

--- a/Cake.UncUtils.nuspec
+++ b/Cake.UncUtils.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
 	<id>Cake.UncUtils</id>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<title>Cake.UncUtils</title>
 	<authors>Lukas Kolletzki</authors>
 	<owners>Lukas Kolletzki</owners>

--- a/Cake.UncUtils.nuspec
+++ b/Cake.UncUtils.nuspec
@@ -14,11 +14,11 @@
 	<copyright>Copyright (c) Lukas Kolletzki 2017</copyright>
 	<dependencies>
 			<group>
-				<dependency id="Cake.Core" version="0.17.0" />
+				<dependency id="Cake.Core" version="0.22.0" />
 			</group>
 	</dependencies>
   </metadata>
   <files>
-  	<file src="Cake.UncUtils/bin/Release/Cake.UncUtils.dll" target="lib/net45" />
+  	<file src="Cake.UncUtils/bin/Release/Cake.UncUtils.dll" target="lib/net46" />
   </files>
 </package>

--- a/Cake.UncUtils/Cake.UncUtils.csproj
+++ b/Cake.UncUtils/Cake.UncUtils.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.UncUtils</RootNamespace>
     <AssemblyName>Cake.UncUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.22.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Cake.Core.0.22.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -50,7 +50,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Cake.UncUtils/packages.config
+++ b/Cake.UncUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.22.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
I simply updated the dependency of Cake.Core to version 0.22.0 and switched the framework version to v4.6 since the addin is not longer compatible with Cake >= 0.22.0

see: [Cakev0.22.0 released](https://www.cakebuild.net/blog/2017/09/cake-v0.22.0-released) for details.

Tests are green and the addin is working fine with cake 0.22.2.